### PR TITLE
atomist/rug#47 always output system dependent EOL chars

### DIFF
--- a/src/main/scala/com/atomist/source/ByteArrayFileArtifact.scala
+++ b/src/main/scala/com/atomist/source/ByteArrayFileArtifact.scala
@@ -5,7 +5,7 @@ import java.io.ByteArrayInputStream
 import com.atomist.source.FileArtifact.DefaultMode
 import com.atomist.util.Utils.withCloseable
 import org.apache.commons.io.IOUtils
-
+import com.atomist.util.Utils.StringImprovements
 /**
   * Simple artifact class containing byte array content.
   */
@@ -41,9 +41,9 @@ case class ByteArrayFileArtifact(
 
   override def isCached = true
 
-  override def content = new String(bytes)
+  override def content: String = new String(bytes).toSystem
 
-  def contentLength = bytes.length
+  def contentLength: Int = new String(bytes).toSystem.length
 
   override def inputStream() = new ByteArrayInputStream(bytes)
 
@@ -62,7 +62,7 @@ object ByteArrayFileArtifact {
     ByteArrayFileArtifact(npath.name, npath.pathElements, bytes, mode, None)
   }
 
-  def toByteArrayFileArtifact(fa: FileArtifact) = fa match {
+  def toByteArrayFileArtifact(fa: FileArtifact): ByteArrayFileArtifact = fa match {
     case bafa: ByteArrayFileArtifact => bafa
     case fa: FileArtifact => new ByteArrayFileArtifact(fa)
   }
@@ -70,15 +70,15 @@ object ByteArrayFileArtifact {
   /**
     * Return an updated version of this file.
     */
-  def updated(fa: FileArtifact, newContent: Array[Byte]) =
+  def updated(fa: FileArtifact, newContent: Array[Byte]): ByteArrayFileArtifact =
     toByteArrayFileArtifact(fa).copy(bytes = newContent)
 
   /**
     * Copy the FileArtifact with a new path.
     */
-  def repathed(fa: FileArtifact, pathElements: Seq[String]) =
+  def repathed(fa: FileArtifact, pathElements: Seq[String]): ByteArrayFileArtifact =
     toByteArrayFileArtifact(fa).copy(pathElements = pathElements)
 
-  def withNewUniqueId(fa: FileArtifact, id: String) =
+  def withNewUniqueId(fa: FileArtifact, id: String): ByteArrayFileArtifact =
     toByteArrayFileArtifact(fa).copy(uniqueId = Some(id))
 }

--- a/src/main/scala/com/atomist/source/StringFileArtifact.scala
+++ b/src/main/scala/com/atomist/source/StringFileArtifact.scala
@@ -1,6 +1,7 @@
 package com.atomist.source
 
 import com.atomist.source.FileArtifact.DefaultMode
+import com.atomist.util.Utils.StringImprovements
 
 /**
   * Simple artifact class containing content.
@@ -8,17 +9,17 @@ import com.atomist.source.FileArtifact.DefaultMode
 case class StringFileArtifact(
                                name: String,
                                pathElements: Seq[String],
-                               override val content: String,
+                               private val _content: String,
                                override val mode: Int,
                                override val uniqueId: Option[String])
   extends NonStreamedFileArtifact {
 
   require(!name.isEmpty, "Name must not be empty")
 
-  def this(name: String, path: String, content: String, mode: Int) =
+  def this(name: String, path: String, _content: String, mode: Int) =
     this(name = name,
       pathElements = if (path == null || "".equals(path)) Nil else path.split("/").toSeq,
-      content = content,
+      _content = _content,
       mode = mode,
       None)
 
@@ -35,13 +36,15 @@ case class StringFileArtifact(
     this(name, pathElements, content, mode, None)
 
   def this(fa: FileArtifact) =
-    this(name = fa.name, pathElements = fa.pathElements, content = fa.content, mode = fa.mode, fa.uniqueId)
+    this(name = fa.name, pathElements = fa.pathElements, _content = fa.content, mode = fa.mode, fa.uniqueId)
 
   override def isCached = true
 
-  def contentLength = content.length
+  def contentLength: Int = _content.toSystem.length
 
-  override def toString = s"${getClass.getSimpleName}:path='[$path]';contentLength=${content.length},mode=$mode,uniqueId=$uniqueId"
+  override def content : String = _content.toSystem
+
+  override def toString = s"${getClass.getSimpleName}:path='[$path]';contentLength=$contentLength,mode=$mode,uniqueId=$uniqueId"
 }
 
 object StringFileArtifact {
@@ -65,7 +68,7 @@ object StringFileArtifact {
   def apply(pathName: String, content: String): StringFileArtifact =
     apply(pathName, content, DefaultMode, None)
 
-  def toStringFileArtifact(fa: FileArtifact) = fa match {
+  def toStringFileArtifact(fa: FileArtifact): StringFileArtifact = fa match {
     case sfa: StringFileArtifact => sfa
     case fa: FileArtifact => new StringFileArtifact(fa)
   }

--- a/src/main/scala/com/atomist/util/Utils.scala
+++ b/src/main/scala/com/atomist/util/Utils.scala
@@ -1,5 +1,6 @@
 package com.atomist.util
 
+import java.io.File
 import java.util.Optional
 
 import scala.language.{implicitConversions, reflectiveCalls}
@@ -55,4 +56,29 @@ object Utils {
 
   def withCloseable[C <: Closeable](f: Unit => C)(block: C => Unit): Unit =
     withCloseable[C, Unit](f)(block)
+
+  def separatorPattern: String ={
+    File.separator match {
+      case """\""" => s"""\\${File.separator}"""
+      case _ => File.separator
+    }
+  }
+
+  implicit class StringImprovements(val s: String) {
+    /**
+      *  Ensure that string is System specific.
+      *  Clean up is expensive, but we should be sure!
+      *  Currently we only incur costs on windows
+       * @return
+      */
+    def toSystem: String = {
+      System.lineSeparator() match {
+        case "\r\n" =>  s.toUnix.replaceAll("\\n", "\r\n")
+        case _ => s
+      }
+    }
+    def toUnix: String = {
+      s.replaceAll("\\r\\n", "\n").replaceAll("\\r", "\n")
+    }
+  }
 }

--- a/src/test/scala/com/atomist/source/ArtifactSourceCollisionTest.scala
+++ b/src/test/scala/com/atomist/source/ArtifactSourceCollisionTest.scala
@@ -6,7 +6,7 @@ class ArtifactSourceCollisionTest extends FlatSpec with Matchers {
 
   it should "allow overwrite of file by default" in {
     val f1 = StringFileArtifact("name", "whatever")
-    val f2 = f1.copy(content = "whatever else")
+    val f2 = f1.copy(_content = "whatever else")
 
     val before = new SimpleFileBasedArtifactSource("", f1)
     val r = before + f2
@@ -17,7 +17,7 @@ class ArtifactSourceCollisionTest extends FlatSpec with Matchers {
 
   it should "allow overwrite of file using ArtifactSource by default" in {
     val f1 = StringFileArtifact("name", "whatever")
-    val f2 = f1.copy(content = "whatever else")
+    val f2 = f1.copy(_content = "whatever else")
 
     val before = new SimpleFileBasedArtifactSource("", f1)
     val toAdd = new SimpleFileBasedArtifactSource("", f2)
@@ -30,7 +30,7 @@ class ArtifactSourceCollisionTest extends FlatSpec with Matchers {
 
   it should "detect file collision" in {
     val f1 = StringFileArtifact("name", "whatever")
-    val f2 = f1.copy(content = "whatever else")
+    val f2 = f1.copy(_content = "whatever else")
     val f3 = StringFileArtifact("quite/something/else", "content doesn't matter")
 
     val before = new SimpleFileBasedArtifactSource("", f1)
@@ -46,7 +46,7 @@ class ArtifactSourceCollisionTest extends FlatSpec with Matchers {
 
   it should "detect file collision in different artifact sources" in {
     val f1 = StringFileArtifact("name", "whatever")
-    val f2 = f1.copy(content = "whatever else")
+    val f2 = f1.copy(_content = "whatever else")
     val f3 = StringFileArtifact("quite/something/else", "content doesn't matter")
 
     val before = new SimpleFileBasedArtifactSource("as1", f1)


### PR DESCRIPTION
Beware! This change ensures that by default the .content method returns strings with EOL for the current system (i.e. \r\n for windows, \n for just about anything else).

This means that any output generated on windows will have windows EOL characters. Most editors shouldn't mind this as we standardise when we read the files in in the first place.

In the future we may want to improve this such that OEL handling is based on the EOL from the original file...