### PR TITLE
Retain cachedDeltas when adding ArtifactSources

### DIFF
--- a/src/main/scala/com/atomist/source/artifactSource.scala
+++ b/src/main/scala/com/atomist/source/artifactSource.scala
@@ -95,13 +95,20 @@ trait ArtifactSource extends RootArtifactContainer {
     */
   def lastModified: Long = throw new UnsupportedOperationException
 
+  /**
+    * Add all artifacts in right to this.  The artifacts in right are also
+    * added to this.cachedDeltas, right.cachedDeltas is ignored.
+    *
+    * @param right ArtifactSource containing artifacts to be added
+    * @return The sum of this and right
+    */
   def plus(right: ArtifactSource): ArtifactSource = {
     val as = new ArtifactSource {
       private val left = ArtifactSource.this
 
       override val id: ArtifactSourceIdentifier = left.id
 
-      override lazy val cachedDeltas: Seq[Delta] =
+      override lazy val cachedDeltas: Seq[Delta] = left.cachedDeltas ++
         (for (newFile <- right.allFiles)
           yield
             left.findFile(newFile.path) match {


### PR DESCRIPTION
The plus method for ArtifactSource was discarding the cachedDeltas in
this, returning an ArtifactSource whose cachedDeltas only contained the
artifacts added from right.  The list of cachedDeltas seems crucial to
actually materializing the results of edits.  Many tests added to
elucidate this behavior.

Addresses atomist/rug#199